### PR TITLE
feat: state demo useCallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 ignore
 node_modules
+
+.idea

--- a/src/StateAndTrust/TrustTree.jsx
+++ b/src/StateAndTrust/TrustTree.jsx
@@ -129,7 +129,10 @@ const icons = [
   "x-octagon-fill",
 ];
 
-const getRandomIcon = () => icons[Math.floor(Math.random() * icons.length)];
+const getRandomIcon = useCallback(() => icons[Math.floor(Math.random() * icons.length)]);
+const updateCircle = useCallback(() => setCircle(getRandomIcon()));
+const updateSquare = useCallback(() => setSquare(getRandomIcon()));
+const updateTriangle = useCallback(() => setTriangle(getRandomIcon()));
 
 return (
   <div>
@@ -144,9 +147,9 @@ return (
           circle,
           square,
           triangle,
-          updateCircle: () => setCircle(getRandomIcon()),
-          updateSquare: () => setSquare(getRandomIcon()),
-          updateTriangle: () => setTriangle(getRandomIcon()),
+          updateCircle,
+          updateSquare,
+          updateTriangle,
         }}
       />
       <Widget
@@ -157,9 +160,9 @@ return (
           circle,
           square,
           triangle,
-          updateCircle: () => setCircle(getRandomIcon()),
-          updateSquare: () => setSquare(getRandomIcon()),
-          updateTriangle: () => setTriangle(getRandomIcon()),
+          updateCircle,
+          updateSquare,
+          updateTriangle,
         }}
       />
     </div>


### PR DESCRIPTION
This PR wraps `useCallback` around the functions in `TrustTree` in the state demo. This addresses the performance issues with state update functions being passed deeply as props.